### PR TITLE
zero missiles count: NPC's shipdata might define a number of missiles…

### DIFF
--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -1675,6 +1675,7 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 		[missile_entity[i] release];
 		missile_entity[i] = nil;
 	}
+	missiles = 0; // dybal: for when the shipdata specified missiles (i.e., a NPC ship that is being used by the player via EscortDeck+HyperspaeHangar)
 	NSArray *missileRoles = [dict oo_arrayForKey:@"missile_roles"];
 	if (missileRoles != nil)
 	{
@@ -5812,7 +5813,7 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 - (BOOL) mountMissile:(ShipEntity *)missile
 {
 	if (missile == nil)  return NO;
-	
+
 	unsigned i;
 	for (i = 0; i < max_missiles; i++)
 	{


### PR DESCRIPTION
… the ship should have and that does not make sense for player ship (and a NPC ship might replace the player ship due to EscortDeck+HyperspaceHangar)